### PR TITLE
Fix numeric input issue on iOS devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secullum-react-native-ui",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -12,7 +12,8 @@ import {
   View,
   ViewStyle,
   TextInputProps,
-  ReturnKeyTypeOptions
+  ReturnKeyTypeOptions,
+  Platform
 } from 'react-native';
 import { isTablet } from '../modules/layout';
 
@@ -121,10 +122,15 @@ export class TextBox extends React.Component<TextBoxProperties> {
       editable: this.props.editable,
       keyboardType: this.props.keyboardType,
       maxLength: this.props.maxLength,
-      returnKeyType: this.props.returnKeyType,
       onSubmitEditing: this.props.onSubmitEditing,
       autoCapitalize: this.props.autoCapitalize,
       autoCorrect: this.props.autoCorrect,
+      returnKeyType:
+        Platform.OS === 'ios' &&
+        this.props.keyboardType === 'numeric' &&
+        this.props.returnKeyType === 'next'
+          ? 'done'
+          : this.props.returnKeyType,
       ref: (input: TextInput) => {
         this.input = input;
         if (inputRef) inputRef(input);


### PR DESCRIPTION
No iOS, ao setar um campo _numeric_ com _returnKeyType_: 'next', o usuário fica impossibilitado de sair do input. 
Para contornar essa limitação, foi acordado que o input seria interpretado como _returnKeyType_: 'done' nesses casos, para que o usuário tenha a possibilidade de deixar o campo pelo botão Done.

O Android não tem essa limitação e o comportamento padrão é mantido.