### PR TITLE
Adjust size of hitbox on the clear button in DatePicker and TimePicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secullum-react-native-ui",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -128,6 +128,7 @@ export class DatePicker extends React.Component<
             style={styles.clearIcon}
             iconColor={value && clearable ? theme.textColor1 : theme.textColor2}
             onPress={value && clearable ? this.handleClear : this.handlePress}
+            hitBoxSize={30}
           />
         </View>
       </TouchableWithoutFeedback>

--- a/src/components/ImageButton.tsx
+++ b/src/components/ImageButton.tsx
@@ -15,17 +15,35 @@ export interface ImageButtonProperties {
   iconColor?: string;
   onPress: () => void;
   iconSize?: number;
+  hitBoxSize?: number;
 }
 
 export class ImageButton extends React.Component<ImageButtonProperties> {
   render() {
-    const { icon, style, iconColor, onPress, iconSize } = this.props;
+    const {
+      icon,
+      style,
+      iconColor,
+      onPress,
+      iconSize,
+      hitBoxSize
+    } = this.props;
 
     return (
       <TouchableOpacity
         onPress={onPress}
         activeOpacity={0.5}
         style={[styles.container, style]}
+        hitSlop={
+          hitBoxSize
+            ? {
+                top: hitBoxSize,
+                bottom: hitBoxSize,
+                left: hitBoxSize,
+                right: hitBoxSize
+              }
+            : undefined
+        }
       >
         <FontAwesome
           name={icon}

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -151,6 +151,7 @@ export class TimePicker extends React.Component<
                 onPress={
                   value && clearable ? this.handleClear : this.handlePress
                 }
+                hitBoxSize={30}
               />
             )}
           </View>


### PR DESCRIPTION
With this adjust, the hit area of the clear button is bigger, so is easier to click it and avoid misclicks. 