### PR TITLE
Component upgrade in order to avoid warning messages when using react native 36 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-native-elevated-view": "^0.0.6",
     "react-native-masked-text": "^1.7.2",
     "react-native-modal-datetime-picker": "8.0.4",
-    "react-native-vector-icons": "4.5.0",
+    "react-native-vector-icons": "^4.5.0",
     "react-native-web-modal": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "docs:publish": "docz build && gh-pages -d .docz/dist"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "^2.1.0",
     "date-fns": "2.0.0-alpha.7",
     "react-date-range": "^1.0.0-beta",
     "react-native-drawer-layout": "^2.0.0",
     "react-native-elevated-view": "^0.0.6",
     "react-native-masked-text": "^1.7.2",
-    "react-native-modal-datetime-picker": "^4.13.0",
-    "react-native-vector-icons": "^4.5.0",
+    "react-native-modal-datetime-picker": "8.0.4",
+    "react-native-vector-icons": "4.5.0",
     "react-native-web-modal": "^1.0.1"
   },
   "devDependencies": {

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -38,8 +38,7 @@ export class DatePicker extends React.Component<
   };
 
   static defaultProps = {
-    clearable: true,
-    isDarkModeEnabled: false    
+    clearable: true
   };
 
   handlePress = () => {
@@ -47,7 +46,7 @@ export class DatePicker extends React.Component<
   };
 
   handleConfirm = (value: Date) => {
-    this.setState({ showModal: false },()=>{
+    this.setState({ showModal: false }, () => {
       this.props.onChange(value);
     });
   };
@@ -102,7 +101,14 @@ export class DatePicker extends React.Component<
   };
 
   render() {
-    const { label, value, clearable, style, nativeID, isDarkModeEnabled } = this.props;
+    const {
+      label,
+      value,
+      clearable,
+      style,
+      nativeID,
+      isDarkModeEnabled
+    } = this.props;
 
     const styles = this.getStyles();
 

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import DateTimePicker from 'react-native-modal-datetime-picker';
+import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import { formatDate } from '../modules/format';
 import { getTheme } from '../modules/theme';
 import { ImageButton } from './ImageButton';
@@ -22,6 +22,7 @@ export interface DatePickerProperties {
   onChange: (value?: Date) => void;
   style?: StyleProp<ViewStyle>;
   nativeID?: string;
+  isDarkModeEnabled: boolean;
 }
 
 export interface DatePickerState {
@@ -32,12 +33,13 @@ export class DatePicker extends React.Component<
   DatePickerProperties,
   DatePickerState
 > {
-  static defaultProps = {
-    clearable: true
-  };
-
   state: DatePickerState = {
     showModal: false
+  };
+
+  static defaultProps = {
+    clearable: true,
+    isDarkModeEnabled: false    
   };
 
   handlePress = () => {
@@ -45,8 +47,9 @@ export class DatePicker extends React.Component<
   };
 
   handleConfirm = (value: Date) => {
-    this.props.onChange(value);
-    this.handleCancel();
+    this.setState({ showModal: false },()=>{
+      this.props.onChange(value);
+    });
   };
 
   handleCancel = () => {
@@ -99,7 +102,7 @@ export class DatePicker extends React.Component<
   };
 
   render() {
-    const { label, value, clearable, style, nativeID } = this.props;
+    const { label, value, clearable, style, nativeID, isDarkModeEnabled } = this.props;
 
     const styles = this.getStyles();
 
@@ -116,11 +119,12 @@ export class DatePicker extends React.Component<
           </View>
 
           {Platform.OS !== 'web' && (
-            <DateTimePicker
+            <DateTimePickerModal
               date={value}
               isVisible={this.state.showModal}
               onConfirm={this.handleConfirm}
               onCancel={this.handleCancel}
+              isDarkModeEnabled={isDarkModeEnabled}
             />
           )}
 

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -33,12 +33,12 @@ export class DatePicker extends React.Component<
   DatePickerProperties,
   DatePickerState
 > {
-  state: DatePickerState = {
-    showModal: false
-  };
-
   static defaultProps = {
     clearable: true
+  };
+
+  state: DatePickerState = {
+    showModal: false
   };
 
   handlePress = () => {

--- a/src/components/RangeDatePicker.tsx
+++ b/src/components/RangeDatePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import DateTimePickerModal from "react-native-modal-datetime-picker";
+import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import { formatDate } from '../modules/format';
 import { getTheme } from '../modules/theme';
@@ -34,14 +34,10 @@ export interface RangeDatePickerState {
 export class RangeDatePicker extends React.Component<
   RangeDatePickerProperties,
   RangeDatePickerState
-  > {
+> {
   state: RangeDatePickerState = {
     showStartDateModal: false,
     showEndDateModal: false
-  };
-
-  static defaultProps = {
-    isDarkModeEnabled: false
   };
 
   handleDatePickerPress = () => {
@@ -51,15 +47,18 @@ export class RangeDatePicker extends React.Component<
   };
 
   handleStartDateConfirm = (date: Date) => {
-    this.setState({
-      showStartDateModal: false,
-      showEndDateModal: true
-    }, () => {
-      if (date > this.props.endDate) {
-        this.props.onEndDateChange(date);
+    this.setState(
+      {
+        showStartDateModal: false,
+        showEndDateModal: true
+      },
+      () => {
+        if (date > this.props.endDate) {
+          this.props.onEndDateChange(date);
+        }
+        this.props.onStartDateChange(date);
       }
-      this.props.onStartDateChange(date);
-    })
+    );
   };
 
   handleStartDateCancel = () => {
@@ -70,11 +69,14 @@ export class RangeDatePicker extends React.Component<
   };
 
   handleEndDateConfirm = (date: Date) => {
-    this.setState({
-      showEndDateModal: false
-    }, () => {
-      this.props.onEndDateChange(date);
-    });
+    this.setState(
+      {
+        showEndDateModal: false
+      },
+      () => {
+        this.props.onEndDateChange(date);
+      }
+    );
   };
 
   handleEndDateCancel = () => {
@@ -123,7 +125,14 @@ export class RangeDatePicker extends React.Component<
   };
 
   render() {
-    const { label, startDate, endDate, style, nativeID, isDarkModeEnabled } = this.props;
+    const {
+      label,
+      startDate,
+      endDate,
+      style,
+      nativeID,
+      isDarkModeEnabled
+    } = this.props;
     const { showStartDateModal, showEndDateModal } = this.state;
 
     const displayFormat = 'MMM D, YYYY';
@@ -163,25 +172,24 @@ export class RangeDatePicker extends React.Component<
               />
             ) : null
           ) : (
-              <>
-                <DateTimePickerModal
-                  date={startDate}
-                  isVisible={showStartDateModal}
-                  onConfirm={this.handleStartDateConfirm}
-                  onCancel={this.handleStartDateCancel}
-                  isDarkModeEnabled={isDarkModeEnabled}
-                />
-                <DateTimePickerModal
-                  date={endDate}
-                  minimumDate={startDate}
-                  isVisible={showEndDateModal}
-                  onConfirm={this.handleEndDateConfirm}
-                  onCancel={this.handleEndDateCancel}
-                  isDarkModeEnabled={isDarkModeEnabled}
-
-                />
-              </>
-            )}
+            <>
+              <DateTimePickerModal
+                date={startDate}
+                isVisible={showStartDateModal}
+                onConfirm={this.handleStartDateConfirm}
+                onCancel={this.handleStartDateCancel}
+                isDarkModeEnabled={isDarkModeEnabled}
+              />
+              <DateTimePickerModal
+                date={endDate}
+                minimumDate={startDate}
+                isVisible={showEndDateModal}
+                onConfirm={this.handleEndDateConfirm}
+                onCancel={this.handleEndDateCancel}
+                isDarkModeEnabled={isDarkModeEnabled}
+              />
+            </>
+          )}
         </View>
       </TouchableWithoutFeedback>
     );

--- a/src/components/RangeDatePicker.tsx
+++ b/src/components/RangeDatePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import DateTimePicker from 'react-native-modal-datetime-picker';
+import DateTimePickerModal from "react-native-modal-datetime-picker";
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import { formatDate } from '../modules/format';
 import { getTheme } from '../modules/theme';
@@ -23,6 +23,7 @@ export interface RangeDatePickerProperties {
   onEndDateCancel?: () => void;
   style?: StyleProp<ViewStyle>;
   nativeID?: string;
+  isDarkModeEnabled: boolean;
 }
 
 export interface RangeDatePickerState {
@@ -33,10 +34,14 @@ export interface RangeDatePickerState {
 export class RangeDatePicker extends React.Component<
   RangeDatePickerProperties,
   RangeDatePickerState
-> {
+  > {
   state: RangeDatePickerState = {
     showStartDateModal: false,
     showEndDateModal: false
+  };
+
+  static defaultProps = {
+    isDarkModeEnabled: false
   };
 
   handleDatePickerPress = () => {
@@ -46,12 +51,15 @@ export class RangeDatePicker extends React.Component<
   };
 
   handleStartDateConfirm = (date: Date) => {
-    if (date > this.props.endDate) {
-      this.props.onEndDateChange(date);
-    }
-
-    this.props.onStartDateChange(date);
-    this.handleStartDateCancel();
+    this.setState({
+      showStartDateModal: false,
+      showEndDateModal: true
+    }, () => {
+      if (date > this.props.endDate) {
+        this.props.onEndDateChange(date);
+      }
+      this.props.onStartDateChange(date);
+    })
   };
 
   handleStartDateCancel = () => {
@@ -62,10 +70,10 @@ export class RangeDatePicker extends React.Component<
   };
 
   handleEndDateConfirm = (date: Date) => {
-    this.props.onEndDateChange(date);
-
     this.setState({
       showEndDateModal: false
+    }, () => {
+      this.props.onEndDateChange(date);
     });
   };
 
@@ -115,7 +123,7 @@ export class RangeDatePicker extends React.Component<
   };
 
   render() {
-    const { label, startDate, endDate, style, nativeID } = this.props;
+    const { label, startDate, endDate, style, nativeID, isDarkModeEnabled } = this.props;
     const { showStartDateModal, showEndDateModal } = this.state;
 
     const displayFormat = 'MMM D, YYYY';
@@ -138,37 +146,42 @@ export class RangeDatePicker extends React.Component<
 
           {Platform.OS === 'ios' ? (
             showStartDateModal ? (
-              <DateTimePicker
+              <DateTimePickerModal
                 date={startDate}
                 isVisible={true}
                 onConfirm={this.handleStartDateConfirm}
                 onCancel={this.handleStartDateCancel}
+                isDarkModeEnabled={isDarkModeEnabled}
               />
             ) : showEndDateModal ? (
-              <DateTimePicker
+              <DateTimePickerModal
                 date={endDate}
                 isVisible={true}
                 onConfirm={this.handleEndDateConfirm}
                 onCancel={this.handleEndDateCancel}
+                isDarkModeEnabled={isDarkModeEnabled}
               />
             ) : null
           ) : (
-            <>
-              <DateTimePicker
-                date={startDate}
-                isVisible={showStartDateModal}
-                onConfirm={this.handleStartDateConfirm}
-                onCancel={this.handleStartDateCancel}
-              />
-              <DateTimePicker
-                date={endDate}
-                minimumDate={startDate}
-                isVisible={showEndDateModal}
-                onConfirm={this.handleEndDateConfirm}
-                onCancel={this.handleEndDateCancel}
-              />
-            </>
-          )}
+              <>
+                <DateTimePickerModal
+                  date={startDate}
+                  isVisible={showStartDateModal}
+                  onConfirm={this.handleStartDateConfirm}
+                  onCancel={this.handleStartDateCancel}
+                  isDarkModeEnabled={isDarkModeEnabled}
+                />
+                <DateTimePickerModal
+                  date={endDate}
+                  minimumDate={startDate}
+                  isVisible={showEndDateModal}
+                  onConfirm={this.handleEndDateConfirm}
+                  onCancel={this.handleEndDateCancel}
+                  isDarkModeEnabled={isDarkModeEnabled}
+
+                />
+              </>
+            )}
         </View>
       </TouchableWithoutFeedback>
     );

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -34,12 +34,12 @@ export class TimePicker extends React.Component<
   TimePickerProperties,
   TimePickerState
 > {
-  state: TimePickerState = {
-    showModal: false
-  };
-
   static defaultProps = {
     clearable: true
+  };
+
+  state: TimePickerState = {
+    showModal: false
   };
 
   handlePress = () => {

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import DateTimePicker from 'react-native-modal-datetime-picker';
+import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import { ImageButton } from './ImageButton';
 import { formatDate } from '../modules/format';
 import { getTheme } from '../modules/theme';
@@ -23,6 +23,7 @@ export interface TimePickerProperties {
   onChange?: (value: string) => void;
   style?: StyleProp<ViewStyle>;
   nativeID?: string;
+  isDarkModeEnabled:boolean;
 }
 
 export interface TimePickerState {
@@ -33,12 +34,13 @@ export class TimePicker extends React.Component<
   TimePickerProperties,
   TimePickerState
 > {
-  static defaultProps = {
-    clearable: true
-  };
-
   state: TimePickerState = {
     showModal: false
+  };
+
+  static defaultProps = {
+    clearable: true,
+    isDarkModeEnabled: false
   };
 
   handlePress = () => {
@@ -46,11 +48,11 @@ export class TimePicker extends React.Component<
   };
 
   handleConfirm = (value: Date) => {
-    if (this.props.onChange) {
-      this.props.onChange(formatDate(value, 'HH:mm'));
-    }
-
-    this.handleCancel();
+    this.setState({ showModal: false },()=>{
+      if (this.props.onChange) {
+        this.props.onChange(formatDate(value, 'HH:mm'));
+      }
+    });
   };
 
   handleCancel = () => {
@@ -104,7 +106,7 @@ export class TimePicker extends React.Component<
   };
 
   render() {
-    const { label, value, clearable, style, disabled, nativeID } = this.props;
+    const { label, value, clearable, style, disabled, nativeID, isDarkModeEnabled } = this.props;
 
     const date = new Date();
     const hourRegex = /(\d{2}):(\d{2})/;
@@ -134,12 +136,13 @@ export class TimePicker extends React.Component<
             </View>
 
             {Platform.OS !== 'web' && (
-              <DateTimePicker
+              <DateTimePickerModal
                 mode="time"
                 date={date}
                 isVisible={this.state.showModal}
                 onConfirm={this.handleConfirm}
                 onCancel={this.handleCancel}
+                isDarkModeEnabled={isDarkModeEnabled}
               />
             )}
 

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -23,7 +23,7 @@ export interface TimePickerProperties {
   onChange?: (value: string) => void;
   style?: StyleProp<ViewStyle>;
   nativeID?: string;
-  isDarkModeEnabled:boolean;
+  isDarkModeEnabled: boolean;
 }
 
 export interface TimePickerState {
@@ -39,8 +39,7 @@ export class TimePicker extends React.Component<
   };
 
   static defaultProps = {
-    clearable: true,
-    isDarkModeEnabled: false
+    clearable: true
   };
 
   handlePress = () => {
@@ -48,7 +47,7 @@ export class TimePicker extends React.Component<
   };
 
   handleConfirm = (value: Date) => {
-    this.setState({ showModal: false },()=>{
+    this.setState({ showModal: false }, () => {
       if (this.props.onChange) {
         this.props.onChange(formatDate(value, 'HH:mm'));
       }
@@ -106,7 +105,15 @@ export class TimePicker extends React.Component<
   };
 
   render() {
-    const { label, value, clearable, style, disabled, nativeID, isDarkModeEnabled } = this.props;
+    const {
+      label,
+      value,
+      clearable,
+      style,
+      disabled,
+      nativeID,
+      isDarkModeEnabled
+    } = this.props;
 
     const date = new Date();
     const hourRegex = /(\d{2}):(\d{2})/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,6 +813,13 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
 
+"@react-native-community/datetimepicker@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-2.1.0.tgz#4e3413462cbbe5c48fab6cebd422835031cdf7b9"
+  integrity sha512-InktUrx0/4JTy1YsgswljgID7oB3L8wkFobRhnLGWPExSsNHeecGW2/nBP31ZaOPHcjVWhpOQMZt0zDpKfGE/Q==
+  dependencies:
+    invariant "^2.2.4"
+
 "@shellscape/koa-send@^4.1.0":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@shellscape/koa-send/-/koa-send-4.1.3.tgz#1a7c8df21f63487e060b7bfd8ed82e1d3c4ae0b0"
@@ -6932,10 +6939,6 @@ moment@2.19.3:
   version "2.19.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
 
-moment@^2.19.0:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
-
 morgan@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -8224,7 +8227,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15:
+prop-types@15, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8232,13 +8235,6 @@ prop-types@15:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
-
-prop-types@15.5.10:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
 
 prop-types@15.6.2, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
@@ -8561,15 +8557,10 @@ react-live@^1.11.0:
     prop-types "^15.5.8"
     unescape "^0.2.0"
 
-react-native-animatable@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.2.4.tgz#b5fb7657e8f6edadbc26697057a327fb920b3039"
-  dependencies:
-    prop-types "^15.5.10"
-
 react-native-drawer-layout@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-2.0.0.tgz#8ce1e4027bd3f3a09045afdb46080e18346be232"
+  integrity sha512-zYmzv+4QKDwxmAj7pF1yr8VUb+Hp7oBlwMjRZsvv56vPwO89I+kPTI8G78uwSNIf5b4e/iOChE4vpB5J2XsJFA==
 
 react-native-elevated-view@^0.0.6:
   version "0.0.6"
@@ -8584,24 +8575,17 @@ react-native-masked-text@^1.7.2:
     moment "2.19.3"
     tinymask "^1.0.2"
 
-react-native-modal-datetime-picker@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-4.13.0.tgz#bcf9f62c691befb133bf6fd6e5d6189d397608ef"
+react-native-modal-datetime-picker@8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-8.0.4.tgz#f3867739b3d9c8f1373b0d93b71d75c15b5e3bf1"
+  integrity sha512-kqz+YzHTSZz28k/Z3tVw82XAi7HnPBNRivIfpPKstfAKi7jz2NuXW/0tv4paj3O0MEFn4oE+yPCPQHSzSNeYMA==
   dependencies:
-    moment "^2.19.0"
-    prop-types "15.5.10"
-    react-native-modal "3.1.0"
+    prop-types "^15.7.2"
 
-react-native-modal@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-3.1.0.tgz#3e6911152e9dcd6e15457cf0c24d7fd833c4a57a"
-  dependencies:
-    prop-types "15.5.10"
-    react-native-animatable "^1.2.3"
-
-react-native-vector-icons@^4.5.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz#e4014311ffa6de397d914ffc31b7097a874cc8d5"
+react-native-vector-icons@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.5.0.tgz#6b95619e64f62f05f579f74a01fe5640df95158b"
+  integrity sha512-A2HdvmYxAohZ3w8FgdMi5kl3pUEXOz9sR3zsfpejIdispqAh6NRAHCqsI6DMRcymNgwWzmqLowPqp9eg5zqWLA==
   dependencies:
     lodash "^4.0.0"
     prop-types "^15.5.10"
@@ -11163,6 +11147,7 @@ yargs@^7.0.0:
 yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  integrity sha1-YpmpBVsc78lp/355wdkY3Osiw2A=
   dependencies:
     camelcase "^4.1.0"
     cliui "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8582,10 +8582,10 @@ react-native-modal-datetime-picker@8.0.4:
   dependencies:
     prop-types "^15.7.2"
 
-react-native-vector-icons@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.5.0.tgz#6b95619e64f62f05f579f74a01fe5640df95158b"
-  integrity sha512-A2HdvmYxAohZ3w8FgdMi5kl3pUEXOz9sR3zsfpejIdispqAh6NRAHCqsI6DMRcymNgwWzmqLowPqp9eg5zqWLA==
+react-native-vector-icons@^4.5.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz#e4014311ffa6de397d914ffc31b7097a874cc8d5"
+  integrity sha512-rpfhfPiXCK2PX1nrNhdxSMrEGB/Gw/SvKoPM0G2wAkSoqynnes19K0VYI+Up7DqR1rFIpE4hP2erpT1tNx2tfg==
   dependencies:
     lodash "^4.0.0"
     prop-types "^15.5.10"


### PR DESCRIPTION
 After upgrading react native from version 34 to 36, react-native-modal-datetimepicker started to throw the following exception: "DatePickerAndroid has been merged with DatePickerIOS and will be removed in a future release. It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'.", in order to fix this issue a new version of 'react-native-modal-datetimepicker' had to be installed.

With the new version of the component it was implemented support for darkMode in the following components: DatePicker, TimePicker and RangeDatePicker.

