### PR TITLE
Expor o método onCancel do componente DateTimePickerModal.

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -21,6 +21,7 @@ export interface DatePickerProperties {
   value?: Date;
   clearable?: boolean;
   onChange: (value?: Date) => void;
+  onCancel?: () => void;
   style?: StyleProp<ViewStyle>;
   nativeID?: string;
 }
@@ -68,7 +69,11 @@ export class DatePicker extends React.Component<
   };
 
   handleCancel = () => {
-    this.setState({ showModal: false });
+    this.setState({ showModal: false }, () => {
+      if (this.props.onCancel) {
+        this.props.onCancel();
+      }
+    });
   };
 
   handleClear = () => {

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -22,6 +22,7 @@ export interface TimePickerProperties {
   clearable?: boolean;
   disabled?: boolean;
   onChange?: (value: string) => void;
+  onCancel?:()=>void;
   style?: StyleProp<ViewStyle>;
   nativeID?: string;
 }
@@ -71,7 +72,12 @@ export class TimePicker extends React.Component<
   };
 
   handleCancel = () => {
-    this.setState({ showModal: false });
+    this.setState({showModal: false},()=>{
+      if (this.props.onCancel){
+        this.props.onCancel();
+      }
+    });
+
   };
 
   handleClear = () => {

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -22,7 +22,7 @@ export interface TimePickerProperties {
   clearable?: boolean;
   disabled?: boolean;
   onChange?: (value: string) => void;
-  onCancel?:()=>void;
+  onCancel?: () => void;
   style?: StyleProp<ViewStyle>;
   nativeID?: string;
 }
@@ -72,12 +72,11 @@ export class TimePicker extends React.Component<
   };
 
   handleCancel = () => {
-    this.setState({showModal: false},()=>{
-      if (this.props.onCancel){
+    this.setState({ showModal: false }, () => {
+      if (this.props.onCancel) {
         this.props.onCancel();
       }
     });
-
   };
 
   handleClear = () => {


### PR DESCRIPTION
Foi necessário criar a propriedade OnCancel no componente TimePicker para que seja possível executar ações caso o usuário cancele a seleção de um horário.