### PR TITLE
Store the date range selected from DateRange component in a state

### DIFF
--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -385,13 +385,12 @@ export class DropDown extends React.Component<
                 style={[
                   styles.modalContainer,
                   Platform.OS === 'web' && {
-                    margin: 'auto',
+                    marginVertical:'10px',
+                    marginHorizontal:'auto',
                     width: '90%',
                     maxWidth: 450,
                     maxHeight: 300,
-                    justifyContent: 'center',
-                    marginBottom: '25%',
-                    marginTop: '10px'
+                    justifyContent: 'center'
                   }
                 ]}
               >

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -390,8 +390,8 @@ export class DropDown extends React.Component<
                     maxWidth: 450,
                     maxHeight: 300,
                     justifyContent: 'center',
-                    marginBottom: '10px',
-                    marginTop: '25%'
+                    marginBottom: '25%',
+                    marginTop: '10px'
                   }
                 ]}
               >

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -391,7 +391,7 @@ export class DropDown extends React.Component<
                     maxHeight: 300,
                     justifyContent: 'center',
                     marginBottom: '10px',
-                    marginTop: '10px'
+                    marginTop: '25%'
                   }
                 ]}
               >

--- a/src/components/RangeDatePicker.web.tsx
+++ b/src/components/RangeDatePicker.web.tsx
@@ -32,6 +32,8 @@ export interface RangeDatePickerProperties {
 export interface RangeDatePickerState {
   showStartDateModal: boolean;
   count: number;
+  localStartDate: Date | undefined;
+  localEndDate: Date | undefined;
 }
 
 export class RangeDatePicker extends React.Component<
@@ -40,7 +42,9 @@ export class RangeDatePicker extends React.Component<
 > {
   state: RangeDatePickerState = {
     showStartDateModal: false,
-    count: 0
+    count: 0,
+    localStartDate: undefined,
+    localEndDate: undefined
   };
 
   private calendarRef = React.createRef<HTMLDivElement>();
@@ -58,7 +62,12 @@ export class RangeDatePicker extends React.Component<
       this.calendarRef.current &&
       !this.calendarRef.current.contains(event.target as Node)
     ) {
-      this.setState({ showStartDateModal: false, count: 0 });
+      this.setState({
+        showStartDateModal: false,
+        count: 0,
+        localStartDate: undefined,
+        localEndDate: undefined
+      });
     }
   };
 
@@ -76,13 +85,18 @@ export class RangeDatePicker extends React.Component<
       // is async, so we wait a little.
       setTimeout(() => this.props.onEndDateChange(ranges.selection.endDate), 1);
 
-      this.setState({ showStartDateModal: false, count: 0 });
+      this.setState({
+        showStartDateModal: false,
+        count: 0,
+        localStartDate: ranges.selection.startDate,
+        localEndDate: ranges.selection.endDate
+      });
 
       return;
     }
 
     this.props.onStartDateChange(ranges.selection.startDate);
-    this.setState({ count: 1 });
+    this.setState({ count: 1, localStartDate: ranges.selection.startDate });
   };
 
   getStyles = () => {
@@ -126,7 +140,7 @@ export class RangeDatePicker extends React.Component<
 
   render() {
     const { label, startDate, endDate, style, nativeID } = this.props;
-    const { showStartDateModal } = this.state;
+    const { showStartDateModal, localStartDate, localEndDate } = this.state;
 
     const displayFormat = 'MMM D, YYYY';
 
@@ -166,8 +180,8 @@ export class RangeDatePicker extends React.Component<
                 showDateDisplay={false}
                 ranges={[
                   {
-                    startDate: startDate,
-                    endDate: endDate,
+                    startDate: localStartDate ? localStartDate : startDate,
+                    endDate: localEndDate ? localEndDate : endDate,
                     key: 'selection'
                   }
                 ]}


### PR DESCRIPTION
Once in a while there are times that the date interval being displayed on the screen is not correct, this is caused mainly by the fact that the dates are being displayed according to the external property updates. In order to avoid such issues, the end date and start date are being saved in the local state so as it will not depend on external properties and display the date range correctly.