### PR TITLE
Add setTimeout to avoid issues on RangeDatePicker

### DIFF
--- a/src/components/RangeDatePicker.tsx
+++ b/src/components/RangeDatePicker.tsx
@@ -70,10 +70,12 @@ export class RangeDatePicker extends React.Component<
         showEndDateModal: true
       },
       () => {
-        if (date > this.props.endDate) {
-          this.props.onEndDateChange(date);
-        }
-        this.props.onStartDateChange(date);
+        setTimeout(() => {
+          if (date > this.props.endDate) {
+            this.props.onEndDateChange(date);
+          }
+          this.props.onStartDateChange(date);
+        }, 1);
       }
     );
   };

--- a/src/components/RangeDatePicker.tsx
+++ b/src/components/RangeDatePicker.tsx
@@ -70,6 +70,9 @@ export class RangeDatePicker extends React.Component<
         showEndDateModal: true
       },
       () => {
+        // When using RangeDatePicker on Android devices the end date modal were not being displayed, in order to avoid it,
+        // the setTimeOut was implemented so as it will set a little delay (enough time to update the state) before execute other functions.
+        // Related issue on gitlab: 3487
         setTimeout(() => {
           if (date > this.props.endDate) {
             this.props.onEndDateChange(date);


### PR DESCRIPTION
When using RangeDatePicker on Android devices the end date modal were not being displayed, in order to avoid it, the setTimeOut was implemented so as it will set a little delay (enough time to update the state) before execute other functions.