### PR TITLE
Fix dynamic island spacing to iOS

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -17,12 +17,16 @@ export class StatusBar extends React.Component {
     const dynamicHeight = () => {
       const deviceId = Device.modelId;
 
+      // When is Android or Web, the modelId is null
+      // So we return the status bar height.
       if (deviceId == null) {
         return getStatusBarHeight();
       }
 
       const iPhoneId = deviceId.substring(6, 8);
 
+      // Dynamic Island is available on iPhone 14 Pro and 14 Pro max
+      // Here´s a list os iPhone´s IDs: https://www.theiphonewiki.com/wiki/Models
       if (iPhoneId < 15) return getStatusBarHeight();
 
       return getStatusBarHeight() + 25;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,3 +1,4 @@
+import * as Device from 'expo-device';
 import * as React from 'react';
 import {
   StatusBar as ReactNativeStatusBar,
@@ -13,10 +14,24 @@ export class StatusBar extends React.Component {
   getStyles = () => {
     const theme = getTheme();
 
+    const dynamicHeight = () => {
+      const deviceId = Device.modelId;
+
+      if (deviceId == null) {
+        return getStatusBarHeight();
+      }
+
+      const iPhoneId = deviceId.substring(6, 8);
+
+      if (iPhoneId < 15) return getStatusBarHeight();
+
+      return getStatusBarHeight() + 25;
+    };
+
     const styles = StyleSheet.create({
       statusBar: {
         backgroundColor: theme.statusBarColor,
-        height: getStatusBarHeight()
+        height: dynamicHeight()
       }
     });
 


### PR DESCRIPTION
On the iPhone 14 pro and 14 pro max, has a new component named of Dynamic Island, that substitue the notch area.

So, we get the device's Identifier and get a little bit spacing to StatusBar to compense the space of Dynamic Island.