### PR TITLE
Remover uso do setNativeProps

### DIFF
--- a/src/components/DatePicker.web.tsx
+++ b/src/components/DatePicker.web.tsx
@@ -129,13 +129,7 @@ export class DatePicker extends React.Component<
     return (
       <TouchableWithoutFeedback onPress={this.handlePress}>
         <View nativeID={nativeID} style={[styles.container, style]}>
-          <View
-            ref={ref =>
-              ref &&
-              ref.setNativeProps &&
-              ref.setNativeProps({ id: 'date-picker' })
-            }
-          >
+          <View nativeID="date-picker">
             <Text style={styles.label}>{label}</Text>
             <Text style={styles.value}>
               {value != undefined ? formatDate(value, dateFormat) : ''}

--- a/src/components/DatePicker.web.tsx
+++ b/src/components/DatePicker.web.tsx
@@ -129,7 +129,7 @@ export class DatePicker extends React.Component<
     return (
       <TouchableWithoutFeedback onPress={this.handlePress}>
         <View nativeID={nativeID} style={[styles.container, style]}>
-          <View nativeID="date-picker">
+          <View>
             <Text style={styles.label}>{label}</Text>
             <Text style={styles.value}>
               {value != undefined ? formatDate(value, dateFormat) : ''}

--- a/src/components/RangeDatePicker.web.tsx
+++ b/src/components/RangeDatePicker.web.tsx
@@ -141,13 +141,7 @@ export class RangeDatePicker extends React.Component<
     return (
       <TouchableWithoutFeedback onPress={this.handleDatePickerPress}>
         <View nativeID={nativeID} style={[styles.container, style]}>
-          <View
-            ref={ref =>
-              ref &&
-              ref.setNativeProps &&
-              ref.setNativeProps({ id: 'range-date-picker' })
-            }
-          >
+          <View nativeID="range-date-picker">
             <Text style={styles.label}>{label}</Text>
             <Text style={styles.value}>{displayText}</Text>
           </View>

--- a/src/components/RangeDatePicker.web.tsx
+++ b/src/components/RangeDatePicker.web.tsx
@@ -141,7 +141,7 @@ export class RangeDatePicker extends React.Component<
     return (
       <TouchableWithoutFeedback onPress={this.handleDatePickerPress}>
         <View nativeID={nativeID} style={[styles.container, style]}>
-          <View nativeID="range-date-picker">
+          <View>
             <Text style={styles.label}>{label}</Text>
             <Text style={styles.value}>{displayText}</Text>
           </View>

--- a/src/components/TextBox.tsx
+++ b/src/components/TextBox.tsx
@@ -179,16 +179,12 @@ export class TextBox extends React.Component<TextBoxProperties> {
       <TouchableWithoutFeedback
         accessible={false}
         onPress={() => (onPress ? onPress() : this.focus())}
-        ref={
-          Platform.OS === 'web'
-            ? ref =>
-                ref &&
-                //@ts-ignore
-                ref.setNativeProps &&
-                //@ts-ignore
-                ref.setNativeProps({ tabIndex: -1 })
-            : undefined
-        }
+        ref={ref => {
+          if (Platform.OS === 'web' && ref != null) {
+            // @ts-ignore na web, a ref recebida é o próprio elemento DOM
+            ref.tabIndex = -1;
+          }
+        }}
       >
         <View
           style={[styles.container, style, editable ? null : styles.readonly]}

--- a/src/components/TimePicker.web.tsx
+++ b/src/components/TimePicker.web.tsx
@@ -81,10 +81,12 @@ export class TimePicker extends React.Component<TimePickerProperties> {
       <TouchableWithoutFeedback
         accessible={false}
         disabled={disabled}
-        ref={ref =>
-          //@ts-ignore
-          ref && ref.setNativeProps && ref.setNativeProps({ tabIndex: -1 })
-        }
+        ref={ref => {
+          if (ref != null) {
+            //@ts-ignore
+            ref.tabIndex = -1;
+          }
+        }}
       >
         <View
           style={[styles.container, style, !disabled ? null : styles.readonly]}


### PR DESCRIPTION
Substituímos o setNativeProps, pois a partir da versão .19 do react-native-web ele foi removido. Então manipulamos o Ref diretamente, pois no ambiente web, a propriedade `ref` é o próprio componente.